### PR TITLE
ミニマップが表示されなくなる問題の修正

### DIFF
--- a/RacingGame_tentative_/Assets/Scripts/Minimap.cs
+++ b/RacingGame_tentative_/Assets/Scripts/Minimap.cs
@@ -2,18 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Minimap : MonoBehaviour {
-	// Start is called before the first frame update
-	void Start() {
-
-	}
-
+public class Minimap : MonoBehaviour
+{
 	// Update is called once per frame
-	void Update() {
+	void Update()
+	{
 		// 追従する
 		var trans = Camera.main.transform;
 
-		transform.position = trans.position;
+		transform.position = new Vector3(trans.position.x, trans.position.y + 300.0f, trans.position.z);
 		var rot = trans.rotation.eulerAngles;
 		transform.rotation = Quaternion.Euler(90.0f, rot.y, rot.z);
 	}


### PR DESCRIPTION
## 概要

マップの高低差がある箇所でミニマップが途切れてしまう問題を修正した
ついでにコーディング規約に則ったソースに修正

## 修正方針

メインカメラのy+300の箇所からマップを撮影するようにした
今後もこの問題が再発した場合は、300の数値を下げればだいたい解決するはず