### PR TITLE
UniRx関連のファイルを.gitignoreに追加

### DIFF
--- a/RacingGame_tentative_/.gitignore
+++ b/RacingGame_tentative_/.gitignore
@@ -53,3 +53,4 @@ sysinfo.txt
 [Aa]ssets/_TerrainAutoUpgrade*
 [Aa]ssets/Scenes/Windridge City Demo Scene*
 [Aa]ssets/TextMesh Pro*
+[Aa]ssets/Plugins/UniRx*

--- a/RacingGame_tentative_/Assets/Plugins.meta
+++ b/RacingGame_tentative_/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc243ae058fb1a2498d0fdd8c2357730
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

UniRx関連のファイルを.gitignoreに追加
個別でUniRxをインポートする必要があります
[Asset StoreのUniRxのページ](https://assetstore.unity.com/packages/tools/integration/unirx-reactive-extensions-for-unity-17276?locale=ja-JP)からDLしてください

Pluginsフォルダをキープするために.gitkeepも追加しています