### PR TITLE
RG-18 DOTweenの導入

### DIFF
--- a/RacingGame_tentative_/.gitignore
+++ b/RacingGame_tentative_/.gitignore
@@ -54,3 +54,4 @@ sysinfo.txt
 [Aa]ssets/Scenes/Windridge City Demo Scene*
 [Aa]ssets/TextMesh Pro*
 [Aa]ssets/Plugins/UniRx*
+[Aa]ssets/Plugins/Demigiant*


### PR DESCRIPTION
## 概要

イージングアセットとしてDOTweenを導入することにした

DOTweenを導入するために、.gitignoreに関連ファイルを追記した